### PR TITLE
feat: Separate home and admin pages

### DIFF
--- a/data/photos.json
+++ b/data/photos.json
@@ -1,1 +1,9 @@
-[]
+[
+    {
+        "id": "5e5ebf5e-0386-48d1-9a4c-782e2b24c8b9",
+        "filename": "test_image.jpg",
+        "description": null,
+        "path": "/uploads/2629b637-54f8-4d33-bf62-d8996dcc52c3.jpg",
+        "price": 0.0
+    }
+]

--- a/test_image.jpg
+++ b/test_image.jpg
@@ -1,0 +1,1 @@
+this is a test image

--- a/uploads/2629b637-54f8-4d33-bf62-d8996dcc52c3.jpg
+++ b/uploads/2629b637-54f8-4d33-bf62-d8996dcc52c3.jpg
@@ -1,0 +1,1 @@
+this is a test image

--- a/verify_home_page.py
+++ b/verify_home_page.py
@@ -1,0 +1,30 @@
+import asyncio
+from playwright.async_api import async_playwright
+from bs4 import BeautifulSoup
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto("http://localhost:8000")
+        await page.wait_for_selector(".gallery-container .gallery-item")
+
+        # Take screenshot
+        screenshot_path = "home_page_no_delete_button.png"
+        await page.screenshot(path=screenshot_path)
+        print(f"Screenshot saved to {screenshot_path}")
+
+        # Check for delete button
+        html_content = await page.content()
+        soup = BeautifulSoup(html_content, 'html.parser')
+        delete_buttons = soup.select('button.delete-btn') # Assuming delete button has class 'delete-btn'
+
+        if not delete_buttons:
+            print("Verification successful: No delete buttons found on the home page.")
+        else:
+            print(f"Verification failed: Found {len(delete_buttons)} delete button(s) on the home page.")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Splits the application into two distinct views:
- A public home page that displays the photo gallery and allows users to add items to their cart.
- A password-protected admin page for uploading and deleting photos.

Introduces HTTP Basic Authentication for the admin page and associated API endpoints.