### PR TITLE
fix: Восстановление логики JS для интеграции с "Новой Почтой"

### DIFF
--- a/frontend/js/checkout.js
+++ b/frontend/js/checkout.js
@@ -6,9 +6,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const deliveryForm = document.getElementById('delivery-form');
     const novaPoshtaDetails = document.getElementById('nova-poshta-details');
     const deliveryMethodRadios = document.querySelectorAll('input[name="deliveryMethod"]');
+    const novaPoshtaDeliveryTypeRadios = document.querySelectorAll('input[name="novaPoshtaDeliveryType"]');
+    const cityInput = document.getElementById('nova-poshta-city-input');
+    const citySuggestions = document.getElementById('city-suggestions');
+    const warehouseSelect = document.getElementById('nova-poshta-warehouse');
+    const courierAddressDiv = document.getElementById('np-courier-address');
 
     // --- Состояние ---
     let cart = [];
+    let selectedCityRef = null;
+    let searchTimeout = null;
 
     // --- Функции ---
     const loadCart = () => {
@@ -83,10 +90,21 @@ document.addEventListener('DOMContentLoaded', () => {
         };
 
         if (deliveryMethod === 'nova-poshta') {
+            const deliveryType = formData.get('novaPoshtaDeliveryType');
             orderData.novaPoshta = {
-                city: formData.get('novaPoshtaCity'),
-                warehouse: formData.get('novaPoshtaWarehouse')
+                deliveryType: deliveryType,
+                city: cityInput.value,
+                cityRef: selectedCityRef
             };
+
+            if (deliveryType === 'courier') {
+                orderData.novaPoshta.street = formData.get('novaPoshtaStreet');
+                orderData.novaPoshta.building = formData.get('novaPoshtaBuilding');
+                orderData.novaPoshta.apartment = formData.get('novaPoshtaApartment');
+            } else {
+                orderData.novaPoshta.warehouse = warehouseSelect.options[warehouseSelect.selectedIndex].text;
+                orderData.novaPoshta.warehouseRef = formData.get('novaPoshtaWarehouse');
+            }
         }
 
         try {
@@ -117,13 +135,114 @@ document.addEventListener('DOMContentLoaded', () => {
     loadCart();
     deliveryForm.addEventListener('submit', handleOrderSubmit);
 
+    const handleCitySearch = async () => {
+        const cityName = cityInput.value.trim();
+        if (cityName.length < 2) {
+            citySuggestions.innerHTML = '';
+            citySuggestions.style.display = 'none';
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/novaposhta/cities', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ cityName })
+            });
+            const data = await response.json();
+
+            citySuggestions.innerHTML = '';
+            if (data.success && data.data.length > 0) {
+                data.data.forEach(city => {
+                    const suggestionDiv = document.createElement('div');
+                    suggestionDiv.textContent = city.Description;
+                    suggestionDiv.dataset.ref = city.Ref;
+                    suggestionDiv.addEventListener('click', () => {
+                        cityInput.value = city.Description;
+                        selectedCityRef = city.Ref;
+                        citySuggestions.style.display = 'none';
+                        loadWarehouses();
+                    });
+                    citySuggestions.appendChild(suggestionDiv);
+                });
+                citySuggestions.style.display = 'block';
+            } else {
+                citySuggestions.style.display = 'none';
+            }
+        } catch (error) {
+            console.error('Ошибка поиска городов:', error);
+        }
+    };
+
+    const loadWarehouses = async () => {
+        if (!selectedCityRef) return;
+
+        const deliveryType = document.querySelector('input[name="novaPoshtaDeliveryType"]:checked').value;
+        let warehouseTypeRef;
+
+        if (deliveryType === 'warehouse') {
+            warehouseTypeRef = '841339c7-591a-42e2-8233-7a0a00f0ed6f';
+        } else if (deliveryType === 'postomat') {
+            warehouseTypeRef = 'f9316480-5f2d-425d-bc2c-ac7cd29decf0';
+        } else {
+            warehouseSelect.innerHTML = '';
+            warehouseSelect.style.display = 'none';
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/novaposhta/warehouses', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ cityRef: selectedCityRef, typeOfWarehouseRef: warehouseTypeRef })
+            });
+            const data = await response.json();
+
+            warehouseSelect.innerHTML = '';
+            if (data.success && data.data.length > 0) {
+                data.data.forEach(warehouse => {
+                    const option = document.createElement('option');
+                    option.value = warehouse.Ref;
+                    option.textContent = warehouse.Description;
+                    warehouseSelect.appendChild(option);
+                });
+                warehouseSelect.style.display = 'block';
+            } else {
+                warehouseSelect.style.display = 'none';
+            }
+        } catch (error) {
+            console.error('Ошибка загрузки отделений:', error);
+        }
+    };
+
+    // --- Обработчики событий ---
     deliveryMethodRadios.forEach(radio => {
         radio.addEventListener('change', () => {
-            if (radio.value === 'nova-poshta') {
-                novaPoshtaDetails.style.display = 'block';
+            novaPoshtaDetails.style.display = radio.value === 'nova-poshta' ? 'block' : 'none';
+        });
+    });
+
+    novaPoshtaDeliveryTypeRadios.forEach(radio => {
+        radio.addEventListener('change', () => {
+            const isCourier = radio.value === 'courier';
+            courierAddressDiv.style.display = isCourier ? 'block' : 'none';
+
+            if (isCourier) {
+                warehouseSelect.style.display = 'none';
             } else {
-                novaPoshtaDetails.style.display = 'none';
+                loadWarehouses();
             }
         });
+    });
+
+    cityInput.addEventListener('input', () => {
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(handleCitySearch, 300); // Задержка для уменьшения кол-ва запросов
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!citySuggestions.contains(e.target) && e.target !== cityInput) {
+            citySuggestions.style.display = 'none';
+        }
     });
 });


### PR DESCRIPTION
Этот коммит восстанавливает недостающую логику в `frontend/js/checkout.js`, которая была случайно утеряна в предыдущем коммите. Теперь фронтенд корректно обрабатывает динамическую загрузку городов и отделений "Новой Почты".