### PR TITLE
fix: Implement pagination for Nova Poshta API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -183,16 +183,32 @@ async def find_warehouses(request: dict):
     if not city_ref:
         raise HTTPException(status_code=400, detail="City ref is required")
 
+    all_warehouses = []
+    page = 1
+    limit = 500
+
     async with httpx.AsyncClient() as client:
-        response = await client.post(NOVA_POSHTA_API_URL, json={
-            "apiKey": NOVA_POSHTA_API_KEY,
-            "modelName": "AddressGeneral",
-            "calledMethod": "getWarehouses",
-            "methodProperties": {
-                "CityRef": city_ref
-            }
-        })
-        return response.json()
+        while True:
+            response = await client.post(NOVA_POSHTA_API_URL, json={
+                "apiKey": NOVA_POSHTA_API_KEY,
+                "modelName": "Address",
+                "calledMethod": "getWarehouses",
+                "methodProperties": {
+                    "CityRef": city_ref,
+                    "Page": str(page),
+                    "Limit": str(limit)
+                }
+            })
+            data = response.json()
+            if data["success"] and data["data"]:
+                all_warehouses.extend(data["data"])
+                if len(data["data"]) < limit:
+                    break
+                page += 1
+            else:
+                break
+
+    return {"success": True, "data": all_warehouses, "errors": [], "warnings": [], "info": []}
 
 # --- CORS Middleware ---
 app.add_middleware(


### PR DESCRIPTION
Implements pagination for the Nova Poshta API's `getWarehouses` method. This resolves an issue where the application failed to load a complete list of warehouses for large cities.

The `find_warehouses` function in `backend/main.py` has been updated to loop through the API's pages, collecting all warehouse results before sending them to the frontend. The `modelName` has also been corrected to `Address` to prevent potential issues.